### PR TITLE
'check' should return 'jwt'

### DIFF
--- a/src/api_handler.js
+++ b/src/api_handler.js
@@ -46,7 +46,8 @@ let continueVerificationHandler = new ContinueVerificationHandler(
   phoneVerificationMgr
 );
 let checkVerificationHandler = new CheckVerificationHandler(
-  phoneVerificationMgr
+  phoneVerificationMgr,
+  fuelTokenMgr
 );
 
 //verifies recaptcha token and provides fuel token

--- a/src/handlers/check_verification.js
+++ b/src/handlers/check_verification.js
@@ -15,8 +15,9 @@ resource description
 - N/A
 */
 class CheckVerificationHandler {
-  constructor(phoneVerificationMgr) {
+  constructor(phoneVerificationMgr, fuelTokenMgr) {
     this.phoneVerificationMgr = phoneVerificationMgr;
+    this.fuelTokenMgr = fuelTokenMgr;
   }
 
   debug(l) {
@@ -59,14 +60,17 @@ class CheckVerificationHandler {
 
     try {
       //Verify & request token
-      this.phoneVerificationMgr.check(deviceKey, code).then((resp, err) => {
+      this.phoneVerificationMgr.check(deviceKey, code).then(async (resp, err) => {
         if (err) {
           throw {
             code: 500,
             message: err.message
           };
         }
-        cb(null, { data: resp.data });
+
+        //Get fuel token
+        let fuelToken = await this.fuelTokenMgr.newToken(deviceKey);
+        cb(null, fuelToken);
       });
     } catch (err) {
       cb({


### PR DESCRIPTION
What should `check` return exactly?
Here `check` returns 
```
{
  'status':  'success',
  'data': <request_id>
}
```
In README.md, it says it should return
```
{
  'status':  'success',
  'data': <jwt>
}
```
Anyway, let me know if I'm wrong, but I think the whole point of this is to get `jwt`?